### PR TITLE
Fix CMake files when using Visual Studio.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -25,6 +25,7 @@ class QcaConan(ConanFile):
 
     def source(self):
         tools.patch(patch_file="patches/qca_relative_imported_include_path.patch")
+        tools.patch(patch_file="patches/qca_target_file_for_configuration.patch")
 
         # Fix QCA's CMAKE_MODULE_PATH:
         replace_in_file("CMakeLists.txt",

--- a/patches/qca_target_file_for_configuration.patch
+++ b/patches/qca_target_file_for_configuration.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/modules/QcaMacro.cmake b/cmake/modules/QcaMacro.cmake
+index 88e3121..7a6b2ed 100644
+--- a/cmake/modules/QcaMacro.cmake
++++ b/cmake/modules/QcaMacro.cmake
+@@ -102,13 +102,8 @@ endmacro(add_qca_test)
+ 
+ macro(install_pdb TARGET INSTALL_PATH)
+   if(MSVC)
+-    get_target_property(LOCATION ${TARGET} LOCATION_DEBUG)
+-    string(REGEX REPLACE "\\.[^.]*$" ".pdb" LOCATION "${LOCATION}")
+-    install(FILES ${LOCATION} DESTINATION ${INSTALL_PATH} CONFIGURATIONS Debug)
+-
+-    get_target_property(LOCATION ${TARGET} LOCATION_RELWITHDEBINFO)
+-    string(REGEX REPLACE "\\.[^.]*$" ".pdb" LOCATION "${LOCATION}")
+-    install(FILES ${LOCATION} DESTINATION ${INSTALL_PATH} CONFIGURATIONS RelWithDebInfo)
++    string(REGEX REPLACE "\\.[^.]*$" ".pdb" LOCATION "$<TARGET_FILE:${TARGET}>")
++    install(FILES ${LOCATION} DESTINATION ${INSTALL_PATH} CONFIGURATIONS Debug;RelWithDebInfo)
+   endif(MSVC)
+ endmacro(install_pdb)
+ 


### PR DESCRIPTION
Error message:
    CMake Error at cmake/modules/QcaMacro.cmake:109 (get_target_property):
      The LOCATION property may not be read from target "qcatool-qt5".  Use the
      target name directly with add_custom_command, or use the generator
      expression $<TARGET_FILE>, as appropriate.

This changeset uses the generator expression `$<TARGET_FILE:target>`.