### PR TITLE
fix libraries being missplaced in lib - moved to bin

### DIFF
--- a/patches/qca_relative_imported_include_path.patch
+++ b/patches/qca_relative_imported_include_path.patch
@@ -1,7 +1,16 @@
-diff -u a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	2020-01-23 18:26:23.243034915 +0000
-+++ b/CMakeLists.txt	2020-01-23 18:56:47.359183279 +0000
-@@ -223,6 +223,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -190,7 +190,7 @@ else( QCA_INSTALL_IN_QT_PREFIX )
+   set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "Directory where lib will install")
+ 
+   set(QCA_PREFIX_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Directory where qca will install")
+-  set(QCA_PLUGINS_INSTALL_DIR "${LIB_INSTALL_DIR}/${QCA_LIB_NAME}" CACHE PATH "Directory where qca plugins will install")
++  set(QCA_PLUGINS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin/${QCA_LIB_NAME}" CACHE PATH "Directory where qca plugins will install")
+   set(QCA_BINARY_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Directory where qca plugins will install")
+   set(QCA_LIBRARY_INSTALL_DIR "${LIB_INSTALL_DIR}" CACHE PATH "Directory where qca library will install")
+   set(QCA_FEATURE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/mkspecs/features" CACHE PATH "Directory where qca feature file will install")
+@@ -223,6 +223,7 @@ foreach(PATH QCA_PLUGINS_INSTALL_DIR
               QCA_LIBRARY_INSTALL_DIR
               QCA_FEATURE_INSTALL_DIR
               QCA_INCLUDE_INSTALL_DIR
@@ -9,7 +18,7 @@ diff -u a/CMakeLists.txt b/CMakeLists.txt
               QCA_PRIVATE_INCLUDE_INSTALL_DIR
               QCA_DOC_INSTALL_DIR
               QCA_MAN_INSTALL_DIR
-@@ -264,6 +265,7 @@
+@@ -264,6 +265,7 @@ if(USE_RELATIVE_PATHS)
                 QCA_LIBRARY_INSTALL_DIR
                 QCA_FEATURE_INSTALL_DIR
                 QCA_INCLUDE_INSTALL_DIR


### PR DESCRIPTION
Here is the required patch. Please review it and commit it. I have seen it working after installation and dlls are put into correct directory.